### PR TITLE
Adding support for Zepto

### DIFF
--- a/jquery.stayInWebApp.js
+++ b/jquery.stayInWebApp.js
@@ -5,7 +5,7 @@
  
 ;(function($) {
 	//extend the jQuery object, adding $.stayInWebApp() as a function
-	$.extend({
+	$.extend($, {
 		stayInWebApp: function(selector) {
 			//detect iOS full screen mode
 			if(("standalone" in window.navigator) && window.navigator.standalone) {
@@ -39,4 +39,4 @@
 			}
 		} //end stayInWebApp func
 	});
-})( jQuery );
+})( window.jQuery || window.Zepto );

--- a/jquery.stayInWebApp.min.js
+++ b/jquery.stayInWebApp.min.js
@@ -2,4 +2,4 @@
  * jQuery stayInWebApp Plugin
  * version: 0.4 (2012-06-19)
  */
-(function($){$.extend({stayInWebApp:function(b){"standalone"in window.navigator&&window.navigator.standalone&&(b||(b="a"),$("body").delegate(b,"click",function(b){if($(this).attr("target")==void 0||$(this).attr("target")==""||$(this).attr("target")=="_self"){var c=$(this).attr("href");if(!c.match(/^http(s?)/g))b.preventDefault(),self.location=c}}))}})})(jQuery);
+ (function(a){a.extend(a,{stayInWebApp:function(b){"standalone"in window.navigator&&window.navigator.standalone&&(b||(b="a"),a("body").delegate(b,"click",function(b){if(a(this).attr("target")==undefined||a(this).attr("target")==""||a(this).attr("target")=="_self"){var c=a(this).attr("href");c.match(/^http(s?)/g)||(b.preventDefault(),self.location=c)}}))}})})(window.jQuery||window.Zepto);


### PR DESCRIPTION
This adds Zepto compatibility for anyone swapping out jQuery for Zepto. (Fairly common for mobile web apps?)

I did some basic testing here and all looks OK:
https://dl.dropbox.com/u/1125125/stay/index.html
