### PR TITLE
I added support for a way to specify keywords that if found in the absolute url, keep the url in the web app. This is so I can add support for multiple subdomains in the app.

### DIFF
--- a/MIT-license.txt
+++ b/MIT-license.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Caleb Begly
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,21 @@ This use only links with the class `stay`.
 	
 Full links (starting with http) will still open in Safari, as well as links with `target="_blank"`.
 
+To prevent an absolute link from opening in safari, add its domain to the absToStay array property of the options object like this:
+
+	$(function() {
+		var options = {
+			selector: "a.stay",
+			absToStay: Array("google.com","test.com","cats"), //allow google.com, test.com, and urls containing the word cats to stay.
+		};
+		$.stayInWebApp(options);
+	});
+
+This can help if you have multiple subdomains eg, test.com, sub.test.com, othersub.test.com. All can be allowed by adding test.com to the array.
 - - - - - - - - - -	
 
 Thanks to [Bryan Murdaugh and David Leininger](http://fivable.com) for the original starting script (mostly for discovering that self.location works).
 
 Thanks to Ben Nadel for posting about how to [detect iOS full screen mode](http://www.bennadel.com/blog/1950-Detecting-iPhone-s-App-Mode-Full-Screen-Mode-For-Web-Applications.htm).
+
+Stay for certain absolute urls added by Caleb R. Begly (techdude)

--- a/README.md
+++ b/README.md
@@ -25,8 +25,12 @@ To prevent an absolute link from opening in safari, add its domain to the absToS
 This can help if you have multiple subdomains eg, test.com, sub.test.com, othersub.test.com. All can be allowed by adding test.com to the array.
 - - - - - - - - - -	
 
+Master code by [Joe Moses (mrmoses)](https://github.com/mrmoses).
+
 Thanks to [Bryan Murdaugh and David Leininger](http://fivable.com) for the original starting script (mostly for discovering that self.location works).
 
 Thanks to Ben Nadel for posting about how to [detect iOS full screen mode](http://www.bennadel.com/blog/1950-Detecting-iPhone-s-App-Mode-Full-Screen-Mode-For-Web-Applications.htm).
 
-Stay for certain absolute urls added by Caleb R. Begly (techdude)
+Stay for certain absolute urls added by [Caleb R. Begly (techdude)](https://github.com/techdude)
+
+Licensed under the MIT License - See [MIT-License.txt](MIT-License.txt)

--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ Thanks to Ben Nadel for posting about how to [detect iOS full screen mode](http:
 
 Stay for certain absolute urls added by [Caleb R. Begly (techdude)](https://github.com/techdude)
 
-Licensed under the MIT License - See [MIT-License.txt](MIT-License.txt)
+Licensed under the MIT License - See [MIT-License.txt](MIT-license.txt)

--- a/jquery.stayInWebApp.js
+++ b/jquery.stayInWebApp.js
@@ -1,39 +1,57 @@
 /*!
  * jQuery stayInWebApp Plugin
+ https://github.com/mrmoses/jQuery.stayInWebApp
+ * keeps all internal links in the webapp
  * version: 0.4 (2012-06-19)
+ commits mmoses and techdude
  */
- 
-;(function($) {
+(function($) {
 	//extend the jQuery object, adding $.stayInWebApp() as a function
 	$.extend({
-		stayInWebApp: function(selector) {
+		stayInWebApp: function(options) {
+			if(typeof options=="string"){ //we were not passed an object, but only a selector
+				//make object
+				options = {selector:options};
+			}
 			//detect iOS full screen mode
+			console.log(options);
 			if(("standalone" in window.navigator) && window.navigator.standalone) {
 				//if the selector is empty, default to all links
-				if(!selector) {
-					selector = 'a';
+				if(!options.selector) {
+					options.selector = 'a';
 				}
 				//bind to the click event of all specified elements
-				$("body").delegate(selector,"click",function(event) {
-					//TODO: execute all other events if this element has more bound events
-					/* NEEDS TESTING
-					for(i = 0; i < $(this).data('events'); i++) {
-						console.log($(this).data('events'));
-					}
-					*/
-				
+				$(options.selector).click(function(event) {
+					
 					//only stay in web app for links that are set to _self (or not set)
 					if($(this).attr("target") == undefined || $(this).attr("target") == "" || $(this).attr("target") == "_self") {
 						//get the destination of the link clicked
 						var dest = $(this).attr("href");
+						var stay = false; //by default, we do not stay.
 
-						//if the destination is an absolute url, ignore it
-						if(!dest.match(/^http(s?)/g)) {
+						if(!dest.match(/^http(s?)/g)) { //local urls, keep
+							stay = true;
+						  
+						} else if(options.absToStay) { //if some absolute urls must stay
+							
+							
+							//loop throught urls and see if this is one of the ones we should keep
+							for(var i = 0; i < options.absToStay.length; i++){
+								if(dest.indexOf(options.absToStay[i]) > 0){
+									stay = true;
+									break;
+								}
+							}
+						}
+						
+						if(stay){ //if we should stay for this url,
 						  //prevent default behavior (opening safari)
 						  event.preventDefault();
 						  //update location of the web app
 						  self.location = dest;
 						}
+						
+						
 					}
 				});
 			}

--- a/jquery.stayInWebApp.min.js
+++ b/jquery.stayInWebApp.min.js
@@ -1,5 +1,6 @@
 /*!
  * jQuery stayInWebApp Plugin
  * version: 0.4 (2012-06-19)
+ * commits by mmoses and techdude
  */
-(function($){$.extend({stayInWebApp:function(b){"standalone"in window.navigator&&window.navigator.standalone&&(b||(b="a"),$("body").delegate(b,"click",function(b){if($(this).attr("target")==void 0||$(this).attr("target")==""||$(this).attr("target")=="_self"){var c=$(this).attr("href");if(!c.match(/^http(s?)/g))b.preventDefault(),self.location=c}}))}})})(jQuery);
+(function($){$.extend({stayInWebApp:function(options){if(typeof options=="string"){options={selector:options}}console.log(options);if(("standalone"in window.navigator)&&window.navigator.standalone){if(!options.selector){options.selector='a'}$(options.selector).click(function(event){if($(this).attr("target")==undefined||$(this).attr("target")==""||$(this).attr("target")=="_self"){var dest=$(this).attr("href");var stay=false;if(!dest.match(/^http(s?)/g)){stay=true}else if(options.absToStay){for(var i=0;i<options.absToStay.length;i++){if(dest.indexOf(options.absToStay[i])>0){stay=true;break}}}if(stay){event.preventDefault();self.location=dest}}})}}})})(jQuery);


### PR DESCRIPTION
Allows support for subdomains to stay inside of the app.
